### PR TITLE
Adding UseScreenResolution()

### DIFF
--- a/Assets/Packages/Blending/Blend/Capture.cs
+++ b/Assets/Packages/Blending/Blend/Capture.cs
@@ -36,5 +36,10 @@ namespace nobnak.Blending {
 			}
 			return _rtex;
 		}
+        public void UseScreenResolution() {
+            _width = null;
+            _height = null;
+        }
+
 	}
 }


### PR DESCRIPTION
Adding UseScreenResolution()  It allows Capture.cs to go back to using
the screen resolution after a different resolution was set in Capture.cs